### PR TITLE
next.config.js modularizeImports 설정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,17 @@
-/** @type {import('next').NextConfig} */
 const removeImports = require('next-remove-imports')();
 
+/** @type {import('next').NextConfig} */
 const nextConfig = removeImports({
   reactStrictMode: true,
+  swcMinify: true,
+  modularizeImports: {
+    '@mui/material': {
+      transform: '@mui/material/{{member}}',
+    },
+    '@mui/icons-material': {
+      transform: '@mui/icons-material/{{member}}',
+    }
+  }
 });
 
 


### PR DESCRIPTION
## 설명
로컬에서 개발할 경우 로딩속도가 느려지는 현상을 수정합니다.

코드상에서 다음과 같이 mui 컴포넌트를 임포트할 경우, mui의 모든 모듈을 import 하기 때문에 속도가 굉장히 느렸습니다.
```tsx
import { Card as MuiCard, CardContent, Typography, Box, Avatar } from '@mui/material';
```

하지만 `next.config.js` 파일에서 `modularizeImport`를 설정하면 
트리쉐이킹(Tree Shaking)이 되기 때문에 필요한 모듈만 가져올 수 있습니다.

네트워크로 결과를 확인해보면 사이즈와 속도가 개선될 걸 확인할 수 있습니다.

**`modularizeImport` 설정 전**
![CleanShot 2023-04-21 at 00 43 33@2x](https://user-images.githubusercontent.com/12439567/233419365-8a3f6dbd-2ff6-4973-b522-549f18590348.png)

**`modularizeImport` 설정 후**
![CleanShot 2023-04-21 at 00 46 16@2x](https://user-images.githubusercontent.com/12439567/233419471-46813c9a-0e89-46f0-96e0-450cdf86a829.png)

## 작업 내용
- `next.config.js` 파일 `modularizeImport` 설정

## 스크린샷

## 참고
- [modularize-imports](https://nextjs.org/docs/advanced-features/compiler#modularize-imports)
