### PR TITLE
글 작성 뒤로가기 이벤트 방지 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,13 +24,14 @@
       "error",
       "always"
     ],
-    "no-unused-vars": "error",
+    "no-unused-vars": "off",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/jsx-no-duplicate-props": "error",
     "react/prop-types": "error",
     "react-hooks/rules-of-hooks": "error",
     "react/jsx-props-no-spreading": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "react/jsx-max-props-per-line": [
       "error",
       {

--- a/src/features/post/PostEditor/PostEditor.tsx
+++ b/src/features/post/PostEditor/PostEditor.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
-import { Button, TextField, Container, Stack } from '@mui/material';
+import { Button, Container, Stack, TextField } from '@mui/material';
 import MDEditorSkeleton from './MDEditorSkeleton';
+import { useBeforeUnload } from '@/hooks/common';
 
-import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
+import "@uiw/react-md-editor/markdown-editor.css";
 
 const MDEditor = dynamic(
   () => import("@uiw/react-md-editor"),
@@ -16,6 +17,8 @@ const MDEditor = dynamic(
 function PostEditor() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+
+  useBeforeUnload({});
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -45,8 +48,20 @@ function PostEditor() {
         textareaProps={{ placeholder: '내용을 입력해주세요.' }}
         onChange={handleChangeContent}
       />
-      <Stack mt={1}>
-        <Button variant='contained'>작성</Button>
+      <Stack
+        marginY={1}
+        gap={1}
+        direction="row"
+        display='flex'
+        justifyContent='flex-end'
+      >
+        <Button
+          href="/"
+          variant="outlined"
+        >
+          취소
+        </Button>
+        <Button variant="contained">등록</Button>
       </Stack>
     </Container >
   );

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,0 +1,1 @@
+export { default as useBeforeUnload } from './useBeforeUnload';

--- a/src/hooks/common/useBeforeUnload.ts
+++ b/src/hooks/common/useBeforeUnload.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+interface UseBeforeUnloadProps {
+  onBeforeUnload?: (e: BeforeUnloadEvent) => void;
+}
+
+function useBeforeUnload({ onBeforeUnload }: UseBeforeUnloadProps) {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+      onBeforeUnload?.(e);
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+}
+
+export default useBeforeUnload;


### PR DESCRIPTION
## 설명
글 작성 시 뒤로가기 이벤트 방지를 추가합니다.

원래는 다음과 같이 브라우저 히스토리를 조작하는 방식으로 해서 자체 모달을 띄우려고 했는데
```js
window.history.pushState(null, null, window.location.pathname);
```

브라우저 히스토리를 인위적으로 조작하는 것이기 때문에 브라우저 탐색에 방해가 될 수 있고
연속으로 클릭한 경우 뒤로가기를 막을 방법이 없기 때문에, 브라우저 자체적으로 처리하는`beforeunload` 이벤트를 사용해서 구현하였습니다.

`beforeunload` 이벤트는 다음 상황에서 발생합니다.
- 뒤로가기
- 탭 닫기
- 새로고침
- 취소 버튼 클릭

제가 다른 사이트 (네이버 블로그나 티스토리) 등에서도 확인해봤는데 브라우저 자체 이벤트를 사용해서 뒤로가기를 방지하고 있더라구요.
혹시 더 좋은 아이디어가 있다면 피드백 부탁드립니다.

## 작업 내용
- `useBeforeUnload` hooks 구현
- 취소 버튼 추가 및 디자인 수정

## 스크린샷
<img width="882" alt="CleanShot 2023-04-25 at 19 34 43@2x" src="https://user-images.githubusercontent.com/12439567/234251498-2ea54384-914e-401a-9524-646a73806448.png">

https://user-images.githubusercontent.com/12439567/234251416-b75832c0-4a0f-40fc-946c-b6dc960434a6.mp4

## 참고
[Window: beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)
